### PR TITLE
I_Error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ SRCS := $(shell find $(SRC_DIRS) -name *.cpp -or -name *.c)
 OBJS := $(SRCS:%.c=$(BUILD_DIR)/%.o)
 DEPS := $(OBJS:.o=.d)
 
+# Compiler parameters
+CC_INCL_DIRS := $(SRC_DIRS:%=-I%)
+
 # Rules
 all: $(OBJS)
 	@echo "Linking objects..."
@@ -30,7 +33,7 @@ $(BUILD_DIR)/%.d: %.c
 $(BUILD_DIR)/%.o: %.c
 	@$(MKDIR_P) $(dir $@)
 	@echo "Compiling $<..."
-	@$(CC) -c $< -o $@
+	@$(CC) -c $< $(CC_INCL_DIRS) -o $@
 
 .PHONY: clean
 clean:

--- a/source/I_Lexer.h
+++ b/source/I_Lexer.h
@@ -5,15 +5,18 @@
 #ifndef _I_LEXER_H
 #define _I_LEXER_H
 
+#include "I_List.h"
 
 typedef struct I_Lexer_t
 {
    /*
-    * Parse a string into a list of tokens.
+    * Lex a string into a list of tokens.
     *
     * @param source - string of source code characters
     * @param tokens - storage for the tokens
     * @pre - tokens is an empty list
+    * @post - tokens that contain strings will point directly to source,
+    *          so deallocating source will invalidate the tokens
     */
    void (*lex)(struct I_Lexer_t *interface, const char *source, I_List_t *tokens);
 } I_Lexer_t;

--- a/source/Lexer_Concrete.c
+++ b/source/Lexer_Concrete.c
@@ -3,13 +3,18 @@
  */
 
 #include "Lexer_Concrete.h"
+#include "util.h"
 
 static void lex(I_Lexer_t *interface, const char *source, I_List_t *tokens)
 {
+   REINTERPRET(instance, interface, Lexer_Concrete_t *);
 
+   Error_Report(instance->errorHandler, "Lexer doesn't do anything yet.");
 }
 
-void Lexer_Concrete_Init(Lexer_Concrete_t *instance)
+void Lexer_Concrete_Init(Lexer_Concrete_t *instance, I_Error_t *errorHandler)
 {
    instance->interface.lex = &lex;
+
+   instance->errorHandler = errorHandler;
 }

--- a/source/Lexer_Concrete.c
+++ b/source/Lexer_Concrete.c
@@ -1,0 +1,15 @@
+/***
+ * File: Lexer_Concrete.c
+ */
+
+#include "Lexer_Concrete.h"
+
+static void lex(I_Lexer_t *interface, const char *source, I_List_t *tokens)
+{
+
+}
+
+void Lexer_Concrete_Init(Lexer_Concrete_t *instance)
+{
+   instance->interface.lex = &lex;
+}

--- a/source/Lexer_Concrete.h
+++ b/source/Lexer_Concrete.h
@@ -7,15 +7,18 @@
 #define _LEXER_CONCRETE_H
 
 #include "I_Lexer.h"
+#include "I_Error.h"
 
 typedef struct
 {
    I_Lexer_t interface;
+
+   I_Error_t *errorHandler;
 } Lexer_Concrete_t;
 
 /*
  * Initialize a Lexer_Concrete.
  */
-void Lexer_Concrete_Init(Lexer_Concrete_t *instance);
+void Lexer_Concrete_Init(Lexer_Concrete_t *instance, I_Error_t *errorHandler);
 
 #endif

--- a/source/Lexer_Concrete.h
+++ b/source/Lexer_Concrete.h
@@ -1,0 +1,21 @@
+/***
+ * File: Lexer_Concrete.h
+ * Desc: Implementation of I_Lexer
+ */
+
+#ifndef _LEXER_CONCRETE_H
+#define _LEXER_CONCRETE_H
+
+#include "I_Lexer.h"
+
+typedef struct
+{
+   I_Lexer_t interface;
+} Lexer_Concrete_t;
+
+/*
+ * Initialize a Lexer_Concrete.
+ */
+void Lexer_Concrete_Init(Lexer_Concrete_t *instance);
+
+#endif

--- a/source/util/I_Error.h
+++ b/source/util/I_Error.h
@@ -16,7 +16,7 @@ typedef struct I_Error_t
    void (*report)(struct I_Error_t *interface, const char *message);
 } I_Error_t;
 
-#define Error_Report((interface), (message)) \
+#define Error_Report(interface, message) \
    (interface)->report((interface), (message))
-   
+
 #endif

--- a/source/util/I_Error.h
+++ b/source/util/I_Error.h
@@ -1,0 +1,22 @@
+/***
+ * File: I_Error.h
+ * Desc: Interface for reporting errors in the compilation process.
+ */
+
+#ifndef _I_ERROR_H
+#define _I_ERROR_H
+
+typedef struct I_Error_t
+{
+   /*
+    * Report that an error occured.
+    *
+    * @param message - the error message
+    */
+   void (*report)(struct I_Error_t *interface, const char *message);
+} I_Error_t;
+
+#define Error_Report((interface), (message)) \
+   (interface)->report((interface), (message))
+   
+#endif

--- a/source/util/Token.h
+++ b/source/util/Token.h
@@ -11,19 +11,46 @@
 enum
 {
 
-   // Literals
-   Token_Type_Identifier,
-   Token_Type_String,
-   Token_Type_Number,
+   // Word-like things: identifiers & literals
+   Token_Type_Identifier_Unknown,   // [#_^-!a-zA-Z]*[a-zA-Z][#_^-!a-zA-Z]* -- at least 1 letter and 1 or more special characters
+   Token_Type_Identifier_Phrasal,   // For now, don't handle phrasal functions
+   Token_Type_Identifier_Keyword,   // For now, don't distinguish keywords until parse step
+   Token_Type_Identifier_Type,      // For now, don't distinguish keywords until parse step
+   Token_Type_Identifier_Variable,  // For now, don't distinguish keywords until parse step
+   Token_Type_Literal_String,       // "Only double quote Strings allowed for now"
+   Token_Type_Literal_Number,       // [0-9]
+   Token_Type_Literal_Symbol,       // :identifier
 
-   // Keywords
-   Token_Type_,
-   Token_Type_,
-   Token_Type_,
-   Token_Type_,
-   Token_Type_,
+   // Single Character Symbols
+   Token_Type_Paren_Left,
+   Token_Type_Paren_Right,
+   Token_Type_SquareBrace_Left,
+   Token_Type_SquareBrace_Right,
+   Token_Type_CurlyBrace_Left,
+   Token_Type_CurlyBrace_Right,
+   Token_Type_Comma,
+   Token_Type_Dot,
+   Token_Type_Question,
+   Token_Type_Backtick,
+   Token_Type_Arroba,
+   Token_Type_Pound,
+   Token_Type_Dollar,
+   Token_Type_Colon,
+   Token_Type_Dash,
+   Token_Type_Plus,
+   Token_Type_Slash,
+   Token_Type_Asterisk,
+   Token_Type_Equal,
+   Token_Type_AngleBracket_Left,
+   Token_Type_AngleBracket_Right,
 
-   Token_Type_,
+   // Multi-character Symbols
+   Token_Type_LessEqual,
+   Token_Type_GreaterEqual,
+   Token_Type_EqualEqual,
+   Token_Type_BangEqual,
+   Token_Type_DotDot,
+   Token_Type_DotDotDot,
 
    // Unknown
    Token_Type_Unknown
@@ -33,6 +60,12 @@ typedef uint8_t Token_Type_t;
 typedef struct
 {
    Token_Type_t type;
+   
+   union
+   {
+      char *lexeme;
+      long value;
+   }
 } Token_t;
 
 #endif

--- a/tdd.mk
+++ b/tdd.mk
@@ -18,7 +18,7 @@ SRC_DIRS := \
 # Specific source files to build into library. Helpful when not all code in a directory can be built for test (hopefully a temporary situation)
 SRC_FILES := \
 	source/Lexer_Concrete.c
-	
+
 # Directories containing unit test code build into the unit test runner
 TEST_SRC_DIRS := \
 	test
@@ -28,6 +28,7 @@ TEST_SRC_FILES := \
 
 # Directories containing mock source files to build into the test runner
 MOCKS_SRC_DIRS := \
+	test/util
 
 ####################
 #--- How and Where

--- a/tdd.mk
+++ b/tdd.mk
@@ -54,6 +54,7 @@ CPPUTEST_PEDANTIC_ERRORS = N
 
 # Flags
 CPPUTEST_CXXFLAGS += \
+	-I$(CPPUTEST_HOME)/include \
 	-I$(CPPUTEST_HOME)/include/CppUTest \
 	-I$(CPPUTEST_HOME)/include/CppUTestExt \
 

--- a/tdd.mk
+++ b/tdd.mk
@@ -17,7 +17,8 @@ SRC_DIRS := \
 
 # Specific source files to build into library. Helpful when not all code in a directory can be built for test (hopefully a temporary situation)
 SRC_FILES := \
-
+	source/Lexer_Concrete.c
+	
 # Directories containing unit test code build into the unit test runner
 TEST_SRC_DIRS := \
 	test

--- a/test/Lexer_Concrete_test.cpp
+++ b/test/Lexer_Concrete_test.cpp
@@ -1,0 +1,21 @@
+#include "TestHarness.h"
+
+extern "C"
+{
+   #include "Lexer_Concrete.h"
+}
+
+TEST_GROUP(Lexer_Concrete)
+{
+   Lexer_Concrete_t lexer;
+
+   void setup()
+   {
+      Lexer_Concrete_Init(&lexer);
+   }
+};
+
+TEST(Lexer_Concrete, FailImmediately)
+{
+   FAIL("Immediately");
+}

--- a/test/Lexer_Concrete_test.cpp
+++ b/test/Lexer_Concrete_test.cpp
@@ -20,6 +20,11 @@ TEST_GROUP(Lexer_Concrete)
    }
 };
 
+TEST(Lexer_Concrete, ImmediatelyThrowsError)
+{
+   
+}
+
 TEST(Lexer_Concrete, FailImmediately)
 {
    FAIL("Immediately");

--- a/test/Lexer_Concrete_test.cpp
+++ b/test/Lexer_Concrete_test.cpp
@@ -1,4 +1,5 @@
 #include "TestHarness.h"
+#include "Error_TestDouble.h"
 
 extern "C"
 {
@@ -7,11 +8,15 @@ extern "C"
 
 TEST_GROUP(Lexer_Concrete)
 {
+   Error_TestDouble_t errorDouble;
+
    Lexer_Concrete_t lexer;
 
    void setup()
    {
-      Lexer_Concrete_Init(&lexer);
+      Error_TestDouble_Init(&errorDouble);
+
+      Lexer_Concrete_Init(&lexer, &errorDouble.interface);
    }
 };
 

--- a/test/util/Error_Mock.cpp
+++ b/test/util/Error_Mock.cpp
@@ -1,0 +1,26 @@
+/***
+ * File: Error_Mock.cpp
+ */
+
+#include "MockSupport.h"
+#include "Error_Mock.h"
+
+extern "C"
+{
+#include "util.h"
+}
+
+static void report(I_Error_t *interface, const char *message)
+{
+   REINTERPRET(instance, interface, Error_Mock_t *);
+
+   mock()
+      .actualCall("report")
+      .onObject(instance)
+      .withParameter("message", message);
+}
+
+void Error_Mock_Init(Error_Mock_t *instance)
+{
+   instance->interface.report = &report;
+}

--- a/test/util/Error_Mock.h
+++ b/test/util/Error_Mock.h
@@ -1,0 +1,24 @@
+/***
+ * File: Error_Mock.h
+ * Desc: Mock implementation of I_Error
+ */
+
+#ifndef _ERROR_MOCK_H
+#define _ERROR_MOCK_H
+
+extern "C"
+{
+   #include "I_Error.h"
+}
+
+typedef struct
+{
+   I_Error_t interface;
+} Error_Mock_t;
+
+/*
+ * Initialize an Error_Mock.
+ */
+void Error_Mock_Init(Error_Mock_t *instance);
+
+#endif

--- a/test/util/Error_TestDouble.cpp
+++ b/test/util/Error_TestDouble.cpp
@@ -1,0 +1,28 @@
+/***
+ * File: Error_TestDouble.cpp
+ */
+
+#include "Error_TestDouble.h"
+
+extern "C"
+{
+   #include <string.h>
+   #include "util.h"
+}
+
+void report(I_Error_t *interface, const char *message)
+{
+   REINTERPRET(instance, interface, Error_TestDouble_t *);
+
+   strncpy(instance->message, message, ERROR_TESTDOUBLE_MAX_MESSAGE_SIZE);
+}
+
+void Error_TestDouble_Init(Error_TestDouble_t *instance)
+{
+   instance->interface.report = &report;
+}
+
+void Error_TestDouble_GetError(Error_TestDouble_t *instance, char *message)
+{
+   message = instance->message;  // Shallow copy
+}

--- a/test/util/Error_TestDouble.cpp
+++ b/test/util/Error_TestDouble.cpp
@@ -10,7 +10,7 @@ extern "C"
    #include "util.h"
 }
 
-void report(I_Error_t *interface, const char *message)
+static void report(I_Error_t *interface, const char *message)
 {
    REINTERPRET(instance, interface, Error_TestDouble_t *);
 

--- a/test/util/Error_TestDouble.h
+++ b/test/util/Error_TestDouble.h
@@ -1,0 +1,34 @@
+/***
+ * File: Error_TestDouble.h
+ * Desc: Basic test implementation of I_Error that stores the most recent error
+ */
+
+#ifndef _ERROR_TESTDOUBLE_H
+#define _ERROR_TESTDOUBLE_H
+
+extern "C"
+{
+   #include "I_Error.h"
+}
+
+#define ERROR_TESTDOUBLE_MAX_MESSAGE_SIZE (256)
+
+typedef struct
+{
+   I_Error_t interface;
+   char message[ERROR_TESTDOUBLE_MAX_MESSAGE_SIZE];
+} Error_TestDouble_t;
+
+/*
+ * Initialize a Error_TestDouble.
+ */
+void Error_TestDouble_Init(Error_TestDouble_t *instance);
+
+/*
+ * Get (shallow copy) the most recently reported error
+ *
+ * @param message - to point to most recent message
+ */
+void Error_TestDouble_GetError(Error_TestDouble_t *instance, char *message);
+
+#endif


### PR DESCRIPTION
A bit of a diversion, but allows for more modular error handling.

The actual way errors are handled and printed is now abstracted so errors for all stages of compilation can now be handled just by a call to `Error_Report()` whenever something goes wrong. The error module then decides whether to crash right away or continue, without needing the lexer, parser, etc. to hold on to that logic.

There is a test double and a mock because I implemented the double first and then realized that a mock is better for tracking exactly what errors get reported and when